### PR TITLE
Fix edit command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,7 +18,6 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-    public static final String MESSAGE_INVALID_EDIT = "Invalid edit, please provide a description";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,6 +18,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_INVALID_EDIT = "Invalid edit, please provide a description";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -40,11 +39,12 @@ public class EditCommand extends Command {
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_CATEGORY + "Clan "
-            + PREFIX_EMAIL + "Kingdom";
+            + PREFIX_DESCRIPTION + "Kingdom";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_CATEGORY_DOESNT_EXIST = "Category doesnt exist!";
+    public static final String MESSAGE_TAG_NOT_EDITED = "Invalid tag edit, please specify new tag to edit";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Index index;
@@ -203,6 +203,9 @@ public class EditCommand extends Command {
          */
         public Optional<Set<Tag>> getTags() {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+        public int getTagSize() {
+            return tags.size();
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -44,9 +44,9 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_CATEGORY_DOESNT_EXIST = "Category doesnt exist!";
-    public static final String MESSAGE_TAG_NOT_EDITED = "Invalid tag edit, please specify new tag to edit";
+    public static final String MESSAGE_TAG_NOT_EDITED = "Invalid tag edit, please specify new tag to edit!";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
-
+    public static final String MESSAGE_EMPTY_DESCRIPTION = "Invalid edit, please provide a description!";
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -83,16 +83,20 @@ public class EditCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
-
     /**
      * Creates and returns a {@code Person} with the details of {@code personToEdit}
      * edited with {@code editPersonDescriptor}.
      */
-    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
+    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor
+            editPersonDescriptor) throws CommandException {
         assert personToEdit != null;
         if (editPersonDescriptor.getCategory() != null) {
             Entry personToEditEntry = personToEdit.getEntry(editPersonDescriptor.getCategory());
-            personToEditEntry.setDescription(editPersonDescriptor.getDescription());
+            if (personToEditEntry == null) {
+                throw new CommandException(MESSAGE_CATEGORY_DOESNT_EXIST);
+            } else {
+                personToEditEntry.setDescription(editPersonDescriptor.getDescription());
+            }
         }
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         personToEdit.setTags(updatedTags);
@@ -167,9 +171,6 @@ public class EditCommand extends Command {
          */
         public boolean isAnyTagEdited() {
             return CollectionUtil.isAnyNonNull(tags);
-        }
-        public EntryList getEntryList() {
-            return this.entryList;
         }
         public void set(String category, Entry entry) {
             Entry e = entryList.get(category);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -167,7 +167,6 @@ public class EditCommand extends Command {
         }
         /**
          * Returns true if at least one field is edited.
-         * Todo change this when implementation done
          */
         public boolean isAnyTagEdited() {
             return CollectionUtil.isAnyNonNull(tags);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -67,7 +67,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
         //check if t/ is specified
-        if (editPersonDescriptor.getTagSize() == 0) {
+        if (editPersonDescriptor.getTags().isPresent() && editPersonDescriptor.getTagSize() == 0) {
             throw new ParseException(EditCommand.MESSAGE_TAG_NOT_EDITED);
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -57,13 +57,14 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.set(category, ParserUtil.parse(category, description));
             editPersonDescriptor.setDescription(description);
         }
+        //check for tags not empty
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
-        // Checks if both category and description are provided.
-        boolean isCategorySpecified = editPersonDescriptor.getCategory() == null
+        // Checks if either category, description or tags are provided.
+        boolean isCategoryNotSpecified = editPersonDescriptor.getCategory() == null
                 || editPersonDescriptor.getCategory().isEmpty();
-        boolean isDescriptionSpecified = editPersonDescriptor.getDescription() == null
+        boolean isDescriptionNotSpecified = editPersonDescriptor.getDescription() == null
                 || editPersonDescriptor.getDescription().isEmpty();
-        if (isCategorySpecified && isDescriptionSpecified && !editPersonDescriptor.isAnyTagEdited()) {
+        if (isCategoryNotSpecified && isDescriptionNotSpecified && !editPersonDescriptor.isAnyTagEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_EDIT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -44,16 +43,18 @@ public class EditCommandParser implements Parser<EditCommand> {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         String category = "";
         String description;
-        if (argMultimap.getValue(PREFIX_CATEGORY).isPresent()) {
-            if (argMultimap.getValue(PREFIX_DESCRIPTION).isEmpty()) {
-                throw new ParseException(MESSAGE_INVALID_EDIT);
+        Optional<String> categoryOptional = argMultimap.getValue(PREFIX_CATEGORY);
+        Optional<String> descriptionOptional = argMultimap.getValue(PREFIX_DESCRIPTION);
+        if (categoryOptional.isPresent()) {
+            category = categoryOptional.get();
+            if (descriptionOptional.isEmpty()) {
+                throw new ParseException(EditCommand.MESSAGE_EMPTY_DESCRIPTION);
             }
-            category = argMultimap.getValue(PREFIX_CATEGORY).get();
             editPersonDescriptor.set(category, ParserUtil.parse(category, category));
             editPersonDescriptor.setCategory(category);
         }
-        if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
-            description = argMultimap.getValue(PREFIX_DESCRIPTION).get();
+        if (descriptionOptional.isPresent()) {
+            description = descriptionOptional.get();
             editPersonDescriptor.set(category, ParserUtil.parse(category, description));
             editPersonDescriptor.setDescription(description);
         }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -57,7 +57,6 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.set(category, ParserUtil.parse(category, description));
             editPersonDescriptor.setDescription(description);
         }
-        //check for tags not empty
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
         // Checks if either category, description or tags are provided.
         boolean isCategoryNotSpecified = editPersonDescriptor.getCategory() == null
@@ -66,6 +65,10 @@ public class EditCommandParser implements Parser<EditCommand> {
                 || editPersonDescriptor.getDescription().isEmpty();
         if (isCategoryNotSpecified && isDescriptionNotSpecified && !editPersonDescriptor.isAnyTagEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+        }
+        //check if t/ is specified
+        if (editPersonDescriptor.getTagSize() == 0) {
+            throw new ParseException(EditCommand.MESSAGE_TAG_NOT_EDITED);
         }
 
         return new EditCommand(index, editPersonDescriptor);
@@ -78,7 +81,6 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
         assert tags != null;
-
         if (tags.isEmpty()) {
             return Optional.empty();
         }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_EDIT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -44,6 +45,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         String category = "";
         String description;
         if (argMultimap.getValue(PREFIX_CATEGORY).isPresent()) {
+            if (argMultimap.getValue(PREFIX_DESCRIPTION).isEmpty()) {
+                throw new ParseException(MESSAGE_INVALID_EDIT);
+            }
             category = argMultimap.getValue(PREFIX_CATEGORY).get();
             editPersonDescriptor.set(category, ParserUtil.parse(category, category));
             editPersonDescriptor.setCategory(category);


### PR DESCRIPTION
Fix edit command 

Bug fix for the edit command
1. Does not detect whether category exists: (FIX) Throws exception if does not exist.
2. When description is not provided, returns null (FIX) Throws an exception if description is not provided.
3. When tag not provided, deletes tag (FIX) Finds if tag present and if tag size = 0, throws an error. 
4. Tag can only edit 1 tag. (FIX) If a person inputs more than 1 tag, the subsequent tags will be deleted. (If want more than 1 tag, concatenate tags prefix) 
5. Cannot change the category name (will issue this as an added additional feature)